### PR TITLE
Removed wait-for-mongo call to fix issues with deployment for Meteor 1.6

### DIFF
--- a/templates/linux/deploy.sh
+++ b/templates/linux/deploy.sh
@@ -138,9 +138,9 @@ fi
 sudo mv tmp/bundle app
 
 #wait and check
-echo "Waiting for MongoDB to initialize. (5 minutes)"
+echo "Waiting for MongoDB to initialize. (extended)"
 . /opt/<%= appName %>/config/env.sh
-wait-for-mongo ${MONGO_URL} 300000
+# wait-for-mongo ${MONGO_URL} 6000000
 
 # restart app
 sudo stop <%= appName %> || :


### PR DESCRIPTION
Issue comes from the wait-for-mongo call, it probably isn't compatible for use with Meteor 1.6